### PR TITLE
Removed debug flag that was causing memory leaks

### DIFF
--- a/rl_modules/gofar_agent.py
+++ b/rl_modules/gofar_agent.py
@@ -10,7 +10,6 @@ from rl_modules.base_agent import BaseAgent
 from rl_modules.models import actor, critic, value
 from rl_modules.discriminator import Discriminator
 
-torch.autograd.set_detect_anomaly(True)
 
 """
 GoFAR (Goal-conditioned f-Advantage Regression)


### PR DESCRIPTION
The `torch.autograd.set_detect_anomaly(True)` flag was causing a memory leak for some environments in the GoFAR agent. Removed it so that training doesn't crash after a few epochs.

Before:
![image](https://user-images.githubusercontent.com/3000253/192119848-8ef72192-f5fe-4c00-b16b-bc85785a5ef4.png)
After:
![image](https://user-images.githubusercontent.com/3000253/192119860-8b4a1481-1528-47c8-8b86-0eca8e1e0356.png)
